### PR TITLE
fix(ci): remove s390x build

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           push: true
           build-args: dnsproxy_version=${{ needs.check_release.outputs.tag }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/ppc64le
           tags: >
             axeleroy/dnsproxy:latest,
             axeleroy/dnsproxy:${{ needs.check_release.outputs.tag }},

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           push: false
           build-args: dnsproxy_version=master
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/ppc64le
           # See https://docs.docker.com/build/ci/github-actions/examples/#github-cache
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Apparently, some dependency of dnsproxy does no longer support s390x architecture, had to remove it for the build to pass.