### PR TITLE
Use drill wrapper instead of dig, to conform to unbound example

### DIFF
--- a/docker-compose-pihole.yml
+++ b/docker-compose-pihole.yml
@@ -43,7 +43,8 @@ services:
     networks:
       - pihole-net
     healthcheck:
-      test: ["CMD", "dig", "-p", "53", "dnssec.works", "@127.0.0.1"]
+      # Use the drill wrapper binary to reduce the exit codes to 0 or 1 for healthchecks
+      test: ['CMD', 'drill-hc', '@127.0.0.1', 'dnssec.works']
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
See klutchell/unbound-docker commit 712af1b
https://github.com/klutchell/unbound-docker/commit/712af1bbb4655f936df24a5226cb4453ccfd9cc9

I was using a stack based on this compose, and my unbound container often said "unhealthy" so I looked around and found this change in the unbound container's docker compose which I thought could be related.

Turns out the problem was not that, it was that my stack was using CMD-SHELL instead of CMD for some reason (the yml said CMD but inspecting the container showed CMD-SHELL) and the unbound container is distroless so it has no shell. But changing the healthcheck test fixed it indirectly.

But I thought it would be good to update this stack to use the same command as the unbound maintainer suggests.